### PR TITLE
Upgrade path for Synfony 4

### DIFF
--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -3,4 +3,4 @@ parameters:
 
 services:
     hackzilla_barcode:
-        class: %hackzilla_barcode.class%
+        class: '%hackzilla_barcode.class%'


### PR DESCRIPTION
The reserved indicator "%" cannot start a plain scalar; you need to quote the scalar at line 6 (near "class: %hackzilla_barcode.class%").